### PR TITLE
Wait for queued builds to start using the queue API.

### DIFF
--- a/Jenkins/InedoExtension/Operations/QueueJenkinsBuildOperation.cs
+++ b/Jenkins/InedoExtension/Operations/QueueJenkinsBuildOperation.cs
@@ -16,7 +16,7 @@ namespace Inedo.Extensions.Jenkins.Operations
     [Tag("jenkins")]
     public sealed class QueueJenkinsBuildOperation : JenkinsOperation
     {
-        private int progressPercent;
+        private volatile OperationProgress progress;
 
         [ScriptAlias("Credentials")]
         [DisplayName("Credentials")]
@@ -35,6 +35,14 @@ namespace Inedo.Extensions.Jenkins.Operations
         public string AdditionalParameters { get; set; }
 
         [Category("Advanced")]
+        [ScriptAlias("WaitForStart")]
+        [DisplayName("Wait for start")]
+        [Description("Ignored if wait for completion is true.")]
+        [DefaultValue(true)]
+        [PlaceholderText("true")]
+        public bool WaitForStart { get; set; } = true;
+
+        [Category("Advanced")]
         [ScriptAlias("WaitForCompletion")]
         [DisplayName("Wait for completion")]
         [DefaultValue(true)]
@@ -44,7 +52,7 @@ namespace Inedo.Extensions.Jenkins.Operations
         [Output]
         [ScriptAlias("JenkinsBuildNumber")]
         [DisplayName("Set build number to variable")]
-        [Description("The Jenkins build number can be output into a runtime variable")]
+        [Description("The Jenkins build number can be output into a runtime variable. Requires wait for start or wait for completion.")]
         [PlaceholderText("e.g. $JenkinsBuildNumber")]
         public string JenkinsBuildNumber { get; set; }
 
@@ -52,28 +60,52 @@ namespace Inedo.Extensions.Jenkins.Operations
         {
             this.LogInformation("Queueing build in Jenkins...");
 
-            this.LogDebug("Determining next build number...");
             var client = new JenkinsClient(this, this);
-            string nextBuildNumber = await client.GetNextBuildNumberAsync(this.JobName).ConfigureAwait(false);
 
-            this.LogInformation($"Triggering Jenkins build #{nextBuildNumber}...");
+            var queueItem = await client.TriggerBuildAsync(this.JobName, this.AdditionalParameters).ConfigureAwait(false);
 
-            await client.TriggerBuildAsync(this.JobName, this.AdditionalParameters).ConfigureAwait(false);
+            this.LogInformation($"Jenkins build queued successfully.");
+            this.LogDebug($"Queue item number: {queueItem}");
 
-            this.LogInformation("Jenkins build queued successfully.");
+            if (!this.WaitForStart && !this.WaitForCompletion)
+            {
+                this.LogDebug("The operation is not configured to wait for the build to start.");
+            }
 
-            this.JenkinsBuildNumber = nextBuildNumber;
+            string buildNumber;
+            string lastReason = null;
+
+            while (true)
+            {
+                await Task.Delay(2 * 1000, context.CancellationToken).ConfigureAwait(false);
+                var info = await client.GetQueuedBuildInfoAsync(queueItem).ConfigureAwait(false);
+                if (!string.IsNullOrEmpty(info.BuildNumber))
+                {
+                    buildNumber = info.BuildNumber;
+                    this.JenkinsBuildNumber = buildNumber;
+                    this.LogInformation($"Build number is {buildNumber}.");
+                    break;
+                }
+
+                if (!string.Equals(lastReason, info.WaitReason))
+                {
+                    this.LogDebug($"Waiting for build to start... ({info.WaitReason})");
+                    lastReason = info.WaitReason;
+                }
+
+                this.progress = new OperationProgress(null, info.WaitReason);
+            }
 
             if (this.WaitForCompletion)
             {
-                this.LogInformation($"Waiting for build {nextBuildNumber} to complete...");
+                this.LogInformation($"Waiting for build {buildNumber} to complete...");
 
                 JenkinsBuild build;
                 int attempts = 5;
                 while (true)
                 {
                     await Task.Delay(2 * 1000, context.CancellationToken).ConfigureAwait(false);
-                    build = await client.GetBuildInfoAsync(this.JobName, nextBuildNumber).ConfigureAwait(false);
+                    build = await client.GetBuildInfoAsync(this.JobName, buildNumber).ConfigureAwait(false);
                     if (build == null)
                     {
                         this.LogDebug("Build information was not returned.");
@@ -91,7 +123,7 @@ namespace Inedo.Extensions.Jenkins.Operations
                     if (!build.Building)
                     {
                         this.LogDebug("Build has finished building.");
-                        this.progressPercent = 100;
+                        this.progress = new OperationProgress(100);
                         break;
                     }
                 }
@@ -109,7 +141,7 @@ namespace Inedo.Extensions.Jenkins.Operations
 
         public override OperationProgress GetProgress()
         {
-            return new OperationProgress(this.progressPercent);
+            return this.progress;
         }
 
         protected override ExtendedRichDescription GetDescription(IOperationConfiguration config)
@@ -127,12 +159,12 @@ namespace Inedo.Extensions.Jenkins.Operations
         {
             if (build == null || build.Duration == null || build.EstimatedDuration == null)
             {
-                this.progressPercent = 0;
+                this.progress = new OperationProgress((int?)null);
             }
             else
             {
                 int progress = ((int)build.Duration * 100) / (int)build.EstimatedDuration;
-                this.progressPercent = Math.Min(progress, 99);
+                this.progress = new OperationProgress(Math.Min(progress, 99));
             }
         }
     }


### PR DESCRIPTION
Ask Jenkins for the queued build's ID instead of guessing it.

Wait for builds in the queue to start by default even if WaitForCompletion is false.

Fixes #19.