### PR TITLE
Branched builds

### DIFF
--- a/Jenkins/InedoExtension/Credentials/JenkinsCredentials.cs
+++ b/Jenkins/InedoExtension/Credentials/JenkinsCredentials.cs
@@ -13,6 +13,7 @@ namespace Inedo.Extensions.Jenkins.Credentials
     [Description("Credentials for Jenkins.")]
     public sealed class JenkinsCredentials : ResourceCredentials, IJenkinsConnectionInfo
     {
+        // Test
         public const string TypeName = "Jenkins";
 
         [Required]

--- a/Jenkins/InedoExtension/Credentials/JenkinsCredentials.cs
+++ b/Jenkins/InedoExtension/Credentials/JenkinsCredentials.cs
@@ -13,7 +13,6 @@ namespace Inedo.Extensions.Jenkins.Credentials
     [Description("Credentials for Jenkins.")]
     public sealed class JenkinsCredentials : ResourceCredentials, IJenkinsConnectionInfo
     {
-        // Test
         public const string TypeName = "Jenkins";
 
         [Required]

--- a/Jenkins/InedoExtension/InedoExtension.csproj
+++ b/Jenkins/InedoExtension/InedoExtension.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Operations\QueueJenkinsBuildOperation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SuggestionProviders\ArtifactNameSuggestionProvider.cs" />
+    <Compile Include="SuggestionProviders\BranchNameSuggestionProvider.cs" />
     <Compile Include="SuggestionProviders\BuildNumberSuggestionProvider.cs" />
     <Compile Include="SuggestionProviders\JobNameSuggestionProvider.cs" />
     <Compile Include="VariableFunctions\JenkinsCsrfProtectionEnabledVariableFunction.cs" />

--- a/Jenkins/InedoExtension/InedoExtension.csproj
+++ b/Jenkins/InedoExtension/InedoExtension.csproj
@@ -74,7 +74,7 @@
     <Compile Include="JenkinsClient.cs" />
     <Compile Include="ListVariableSources\JenkinsBranchNameVariableSource.cs" />
     <Compile Include="ListVariableSources\JenkinsBuildNumberVariableSource.cs" />
-    <Compile Include="Message.cs" />
+    <Compile Include="InlineIf.cs" />
     <Compile Include="Operations\DownloadJenkinsArtifactOperation.cs" />
     <Compile Include="Operations\ImportJenkinsArtifactOperation.cs" />
     <Compile Include="Operations\IQueueJenkinsBuildArgs.cs" />
@@ -85,6 +85,7 @@
     <Compile Include="SuggestionProviders\BranchNameSuggestionProvider.cs" />
     <Compile Include="SuggestionProviders\BuildNumberSuggestionProvider.cs" />
     <Compile Include="SuggestionProviders\JobNameSuggestionProvider.cs" />
+    <Compile Include="VariableFunctions\GetJenkinsUrlVariableFunction.cs" />
     <Compile Include="VariableFunctions\JenkinsCsrfProtectionEnabledVariableFunction.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Jenkins/InedoExtension/InedoExtension.csproj
+++ b/Jenkins/InedoExtension/InedoExtension.csproj
@@ -74,6 +74,7 @@
     <Compile Include="JenkinsClient.cs" />
     <Compile Include="ListVariableSources\JenkinsBranchNameVariableSource.cs" />
     <Compile Include="ListVariableSources\JenkinsBuildNumberVariableSource.cs" />
+    <Compile Include="Message.cs" />
     <Compile Include="Operations\DownloadJenkinsArtifactOperation.cs" />
     <Compile Include="Operations\ImportJenkinsArtifactOperation.cs" />
     <Compile Include="Operations\IQueueJenkinsBuildArgs.cs" />

--- a/Jenkins/InedoExtension/InedoExtension.csproj
+++ b/Jenkins/InedoExtension/InedoExtension.csproj
@@ -72,6 +72,7 @@
     <Compile Include="IJenkinsConnectionInfo.cs" />
     <Compile Include="JenkinsArtifactImporter.cs" />
     <Compile Include="JenkinsClient.cs" />
+    <Compile Include="ListVariableSources\JenkinsBranchNameVariableSource.cs" />
     <Compile Include="ListVariableSources\JenkinsBuildNumberVariableSource.cs" />
     <Compile Include="Operations\DownloadJenkinsArtifactOperation.cs" />
     <Compile Include="Operations\ImportJenkinsArtifactOperation.cs" />

--- a/Jenkins/InedoExtension/InedoExtension.csproj
+++ b/Jenkins/InedoExtension/InedoExtension.csproj
@@ -85,6 +85,7 @@
     <Compile Include="SuggestionProviders\BranchNameSuggestionProvider.cs" />
     <Compile Include="SuggestionProviders\BuildNumberSuggestionProvider.cs" />
     <Compile Include="SuggestionProviders\JobNameSuggestionProvider.cs" />
+    <Compile Include="VariableFunctions\GetJenkinsBranchNameVariableFunction.cs" />
     <Compile Include="VariableFunctions\GetJenkinsUrlVariableFunction.cs" />
     <Compile Include="VariableFunctions\JenkinsCsrfProtectionEnabledVariableFunction.cs" />
   </ItemGroup>

--- a/Jenkins/InedoExtension/InlineIf.cs
+++ b/Jenkins/InedoExtension/InlineIf.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Inedo.Extensions.Jenkins
 {
-    public static class Message
+    public static class InlineIf
     {
         public static string IfHasValue(string value, string msg)
         {

--- a/Jenkins/InedoExtension/JenkinsArtifactImporter.cs
+++ b/Jenkins/InedoExtension/JenkinsArtifactImporter.cs
@@ -15,6 +15,7 @@ namespace Inedo.Extensions.Jenkins
     {
         public string ArtifactName { get; set; }
         public string JobName { get; set; }
+        public string BranchName { get; set; }
         public string BuildNumber { get; set; }
 
         public IJenkinsConnectionInfo ConnectionInfo { get; }
@@ -59,7 +60,7 @@ namespace Inedo.Extensions.Jenkins
                 this.Logger.LogDebug("Temp file: " + zipFileName);
 
                 this.Logger.LogDebug("Downloading artifact...");
-                await client.DownloadArtifactAsync(this.JobName, jenkinsBuildNumber, zipFileName).ConfigureAwait(false);
+                await client.DownloadArtifactAsync(this.JobName, jenkinsBuildNumber, zipFileName, this.BranchName).ConfigureAwait(false);
                 this.Logger.LogInformation("Artifact downloaded.");
 
                 using (var file = FileEx.Open(zipFileName, FileMode.Open, FileAccess.Read, FileShare.Read))
@@ -104,7 +105,7 @@ namespace Inedo.Extensions.Jenkins
 
             this.Logger.LogDebug($"Build number is not an integer, resolving special build number \"{this.BuildNumber}\"...");
             var client = new JenkinsClient(this.ConnectionInfo, this.Logger, default);
-            return client.GetSpecialBuildNumberAsync(this.JobName, this.BuildNumber);
+            return client.GetSpecialBuildNumberAsync(this.JobName, this.BuildNumber, this.BranchName);
         }
 
         private static string TrimWhitespaceAndZipExtension(string artifactName)

--- a/Jenkins/InedoExtension/JenkinsArtifactImporter.cs
+++ b/Jenkins/InedoExtension/JenkinsArtifactImporter.cs
@@ -1,4 +1,4 @@
-﻿using static Inedo.Extensions.Jenkins.Message;
+﻿using static Inedo.Extensions.Jenkins.InlineIf;
 using System;
 using System.IO;
 using System.Linq;

--- a/Jenkins/InedoExtension/JenkinsArtifactImporter.cs
+++ b/Jenkins/InedoExtension/JenkinsArtifactImporter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using static Inedo.Extensions.Jenkins.Message;
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -44,8 +45,8 @@ namespace Inedo.Extensions.Jenkins
             if (string.IsNullOrEmpty(jenkinsBuildNumber))
             {
                 this.Logger.LogError($"An error occurred attempting to resolve Jenkins build number \"{this.BuildNumber}\". "
-                   + $"This can mean that the special build type was not found, there are no builds for job \"{this.JobName}\", "
-                   +"or that the job was not found or is disabled."
+                   + $"This can mean that the special build type was not found, there are no builds for job \"{this.JobName}\"{IfHasValue(this.BranchName, $" on branch \"{this.BranchName}\"")},"
+                   + "or that the job was not found or is disabled."
                 );
 
                 return null;
@@ -53,7 +54,7 @@ namespace Inedo.Extensions.Jenkins
 
             try
             {
-                this.Logger.LogInformation($"Importing {this.ArtifactName} from {this.JobName}...");
+                this.Logger.LogInformation($"Importing artifact from job \"{this.JobName}\"{IfHasValue(this.BranchName, $" on branch \"{this.BranchName}\"")} for build #{jenkinsBuildNumber}...");
                 var client = new JenkinsClient(this.ConnectionInfo, this.Logger, default);
 
                 zipFileName = Path.GetTempFileName();

--- a/Jenkins/InedoExtension/JenkinsArtifactImporter.cs
+++ b/Jenkins/InedoExtension/JenkinsArtifactImporter.cs
@@ -38,8 +38,6 @@ namespace Inedo.Extensions.Jenkins
 
         public async Task<string> ImportAsync()
         {
-            this.Logger.LogInformation($"Importing artifact \"{this.ArtifactName}\" from Jenkins...");
-
             string zipFileName = null;
             string jenkinsBuildNumber = await this.ResolveJenkinsBuildNumber().ConfigureAwait(false);
             if (string.IsNullOrEmpty(jenkinsBuildNumber))
@@ -104,7 +102,7 @@ namespace Inedo.Extensions.Jenkins
             if (AH.ParseInt(this.BuildNumber) != null)
                 return Task.FromResult(this.BuildNumber);
 
-            this.Logger.LogDebug($"Build number is not an integer, resolving special build number \"{this.BuildNumber}\"...");
+            this.Logger.LogInformation($"Build number is not an integer, resolving special build number \"{this.BuildNumber}\"...");
             var client = new JenkinsClient(this.ConnectionInfo, this.Logger, default);
             return client.GetSpecialBuildNumberAsync(this.JobName, this.BranchName, this.BuildNumber);
         }

--- a/Jenkins/InedoExtension/JenkinsArtifactImporter.cs
+++ b/Jenkins/InedoExtension/JenkinsArtifactImporter.cs
@@ -60,7 +60,7 @@ namespace Inedo.Extensions.Jenkins
                 this.Logger.LogDebug("Temp file: " + zipFileName);
 
                 this.Logger.LogDebug("Downloading artifact...");
-                await client.DownloadArtifactAsync(this.JobName, jenkinsBuildNumber, zipFileName, this.BranchName).ConfigureAwait(false);
+                await client.DownloadArtifactAsync(this.JobName, this.BranchName, jenkinsBuildNumber, zipFileName).ConfigureAwait(false);
                 this.Logger.LogInformation("Artifact downloaded.");
 
                 using (var file = FileEx.Open(zipFileName, FileMode.Open, FileAccess.Read, FileShare.Read))
@@ -105,7 +105,7 @@ namespace Inedo.Extensions.Jenkins
 
             this.Logger.LogDebug($"Build number is not an integer, resolving special build number \"{this.BuildNumber}\"...");
             var client = new JenkinsClient(this.ConnectionInfo, this.Logger, default);
-            return client.GetSpecialBuildNumberAsync(this.JobName, this.BuildNumber, this.BranchName);
+            return client.GetSpecialBuildNumberAsync(this.JobName, this.BranchName, this.BuildNumber);
         }
 
         private static string TrimWhitespaceAndZipExtension(string artifactName)

--- a/Jenkins/InedoExtension/JenkinsClient.cs
+++ b/Jenkins/InedoExtension/JenkinsClient.cs
@@ -163,7 +163,7 @@ namespace Inedo.Extensions.Jenkins
             return url;
         }
 
-        public static string GetPath(string jobName, string branchName, string buildNumber)
+        public static string GetPath(string jobName, string branchName = null, string buildNumber = null)
         {
             string path = $"job/{Uri.EscapeUriString(jobName)}";
 

--- a/Jenkins/InedoExtension/JenkinsClient.cs
+++ b/Jenkins/InedoExtension/JenkinsClient.cs
@@ -24,7 +24,7 @@ namespace Inedo.Extensions.Jenkins
 
         private static readonly string[] BuiltInBuildNumbers = { "lastSuccessfulBuild", "lastStableBuild", "lastBuild", "lastCompletedBuild" };
 
-        private IJenkinsConnectionInfo config;
+        private readonly IJenkinsConnectionInfo config;
         private readonly ILogSink logger;
         private readonly CancellationToken cancellationToken;
 

--- a/Jenkins/InedoExtension/JenkinsClient.cs
+++ b/Jenkins/InedoExtension/JenkinsClient.cs
@@ -5,12 +5,14 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Inedo.Diagnostics;
 using Inedo.IO;
 
+[assembly: InternalsVisibleTo("InedoExtensionTests")]
 namespace Inedo.Extensions.Jenkins
 {
     internal sealed class JenkinsClient

--- a/Jenkins/InedoExtension/JenkinsClient.cs
+++ b/Jenkins/InedoExtension/JenkinsClient.cs
@@ -161,6 +161,16 @@ namespace Inedo.Extensions.Jenkins
 
             return BuiltInBuildNumbers.Concat(results).ToList();
         }
+        public async Task<List<string>> GetBranchNamesAsync(string jobName)
+        {
+            string result = await this.GetAsync("job/" + Uri.EscapeUriString(jobName) + "/api/xml?xpath=/freeStyleProject/build/number&wrapper=builds").ConfigureAwait(false);
+            var results = XDocument.Parse(result)
+                .Descendants("number")
+                .Select(n => n.Value)
+                .Where(s => !string.IsNullOrEmpty(s));
+
+            return BuiltInBuildNumbers.Concat(results).ToList();
+        }
 
         public Task DownloadArtifactAsync(string jobName, string buildNumber, string fileName)
         {

--- a/Jenkins/InedoExtension/JenkinsClient.cs
+++ b/Jenkins/InedoExtension/JenkinsClient.cs
@@ -237,9 +237,9 @@ namespace Inedo.Extensions.Jenkins
             return this.OpenAsync("/job/" + Uri.EscapeUriString(jobName) + '/' + Uri.EscapeUriString(buildNumber) + "/artifact/*zip*/archive.zip");
         }
 
-        public async Task<List<JenkinsBuildArtifact>> GetBuildArtifactsAsync(string jobName, string buildNumber)
+        public async Task<List<JenkinsBuildArtifact>> GetBuildArtifactsAsync(string jobName, string buildNumber, string branchName = null)
         {
-            string result = await this.GetAsync("job/" + Uri.EscapeUriString(jobName) + "/" + Uri.EscapeUriString(buildNumber) + "/api/xml").ConfigureAwait(false);
+            string result = await this.GetAsync(GetBuildUrl(jobName, branchName, buildNumber, "tree=artifacts[*]")).ConfigureAwait(false);
             return XDocument.Parse(result)
                 .Descendants("artifact")
                 .Select(n => new JenkinsBuildArtifact

--- a/Jenkins/InedoExtension/JenkinsClient.cs
+++ b/Jenkins/InedoExtension/JenkinsClient.cs
@@ -187,7 +187,7 @@ namespace Inedo.Extensions.Jenkins
                 .ToArray();
         }
 
-        public async Task<string> GetSpecialBuildNumberAsync(string jobName, string specialBuildNumber, string branchName = null)
+        public async Task<string> GetSpecialBuildNumberAsync(string jobName, string branchName, string specialBuildNumber)
         {
             string result = await this.GetAsync(GetXmlApiUrl(jobName, branchName, null, $"tree={specialBuildNumber}[number]")).ConfigureAwait(false);
 
@@ -197,7 +197,7 @@ namespace Inedo.Extensions.Jenkins
                 .FirstOrDefault();
         }
 
-        public async Task<List<string>> GetBuildNumbersAsync(string jobName, string branchName = null)
+        public async Task<List<string>> GetBuildNumbersAsync(string jobName, string branchName)
         {
             string result = await this.GetAsync(GetXmlApiUrl(jobName, branchName, null, "tree=builds[number]")).ConfigureAwait(false);
             var results = XDocument.Parse(result)
@@ -223,7 +223,7 @@ namespace Inedo.Extensions.Jenkins
                 .ToList();
         }
         
-        public async Task<JenkinsBuild> GetBuildInfoAsync(string jobName, string buildNumber, string branchName = null)
+        public async Task<JenkinsBuild> GetBuildInfoAsync(string jobName, string branchName, string buildNumber)
         {
             var xml = await this.GetAsync(GetXmlApiUrl(jobName, branchName, buildNumber, "tree=building,result,number,duration,estimatedDuration"), NotFoundAction.ReturnNull).ConfigureAwait(false);
 
@@ -242,7 +242,7 @@ namespace Inedo.Extensions.Jenkins
             };
         }
 
-        public async Task<List<JenkinsBuildArtifact>> GetBuildArtifactsAsync(string jobName, string buildNumber, string branchName = null)
+        public async Task<List<JenkinsBuildArtifact>> GetBuildArtifactsAsync(string jobName, string branchName, string buildNumber)
         {
             string result = await this.GetAsync(GetXmlApiUrl(jobName, branchName, buildNumber, "tree=artifacts[*]")).ConfigureAwait(false);
             return XDocument.Parse(result)
@@ -281,27 +281,27 @@ namespace Inedo.Extensions.Jenkins
             }
         }
 
-        public Task DownloadArtifactAsync(string jobName, string buildNumber, string fileName, string branchName = null)
+        public Task DownloadArtifactAsync(string jobName, string branchName, string buildNumber, string fileName)
         {
             return this.DownloadAsync(GetApiUrl(jobName, branchName, buildNumber, "artifact/*zip*/archive.zip"), fileName);
         }
 
-        public Task DownloadSingleArtifactAsync(string jobName, string buildNumber, string fileName, JenkinsBuildArtifact artifact, string branchName = null)
+        public Task DownloadSingleArtifactAsync(string jobName, string branchName, string buildNumber, string fileName, JenkinsBuildArtifact artifact)
         {
             return this.DownloadAsync(GetApiUrl(jobName, branchName, buildNumber, $"artifact/{artifact.RelativePath}"), fileName);
         }
 
-        public Task<OpenArtifact> OpenArtifactAsync(string jobName, string buildNumber, string branchName = null)
+        public Task<OpenArtifact> OpenArtifactAsync(string jobName, string branchName, string buildNumber)
         {
             return this.OpenAsync(GetApiUrl(jobName, branchName, buildNumber, "artifact/*zip*/archive.zip"));
         }
 
-        public Task<OpenArtifact> OpenSingleArtifactAsync(string jobName, string buildNumber, JenkinsBuildArtifact artifact, string branchName = null)
+        public Task<OpenArtifact> OpenSingleArtifactAsync(string jobName, string branchName, string buildNumber, JenkinsBuildArtifact artifact)
         {
             return this.OpenAsync(GetApiUrl(jobName, branchName, buildNumber, $"artifact/{artifact.RelativePath}"));
         }
 
-        public async Task<int> TriggerBuildAsync(string jobName, string additionalParameters = null, string branchName = null)
+        public async Task<int> TriggerBuildAsync(string jobName, string branchName, string additionalParameters = null)
         {
             var url = GetApiUrl(jobName, branchName, null, "build");            
             if (!string.IsNullOrEmpty(additionalParameters))

--- a/Jenkins/InedoExtension/JenkinsClient.cs
+++ b/Jenkins/InedoExtension/JenkinsClient.cs
@@ -141,15 +141,9 @@ namespace Inedo.Extensions.Jenkins
 
         private string GetXmlApiUrl(string jobName, string branchName, string buildNumber, string queryString)
         {
-            string url = $"job/{Uri.EscapeUriString(jobName)}/";
+            string url = GetPath(jobName, branchName, buildNumber);
 
-            if (!String.IsNullOrEmpty(branchName))
-                url += $"job/{Uri.EscapeUriString(branchName)}/";
-
-            if (!String.IsNullOrEmpty(buildNumber))
-                url += $"{buildNumber}/";
-
-            url += "api/xml";
+            url += "/api/xml";
 
             if (!String.IsNullOrEmpty(queryString))
             {
@@ -161,18 +155,25 @@ namespace Inedo.Extensions.Jenkins
 
         private string GetApiUrl(string jobName, string branchName, string buildNumber, string path)
         {
-            string url = $"job/{Uri.EscapeUriString(jobName)}/";
-
-            if (!String.IsNullOrEmpty(branchName))
-                url += $"job/{Uri.EscapeUriString(branchName)}/";
-
-            if (!String.IsNullOrEmpty(buildNumber))
-                url += $"{buildNumber}/";
+            string url = GetPath(jobName, branchName, buildNumber);
 
             if (!String.IsNullOrEmpty(path))
-                url += path;
+                url += $"/{path}";
             
             return url;
+        }
+
+        public static string GetPath(string jobName, string branchName, string buildNumber)
+        {
+            string path = $"job/{Uri.EscapeUriString(jobName)}";
+
+            if (!String.IsNullOrEmpty(branchName))
+                path += $"/job/{Uri.EscapeUriString(branchName)}";
+
+            if (!String.IsNullOrEmpty(buildNumber))
+                path += $"/{buildNumber}";
+
+            return path;
         }
 
         public async Task<string[]> GetJobNamesAsync()

--- a/Jenkins/InedoExtension/JenkinsClient.cs
+++ b/Jenkins/InedoExtension/JenkinsClient.cs
@@ -199,7 +199,7 @@ namespace Inedo.Extensions.Jenkins
 
         public async Task<List<string>> GetBuildNumbersAsync(string jobName, string branchName = null)
         {
-            string result = await this.GetAsync(GetXmlApiUrl(jobName, branchName, null, "/api/xml?tree=builds[number]")).ConfigureAwait(false);
+            string result = await this.GetAsync(GetXmlApiUrl(jobName, branchName, null, "tree=builds[number]")).ConfigureAwait(false);
             var results = XDocument.Parse(result)
                 .Descendants("number")
                 .Select(n => n.Value)

--- a/Jenkins/InedoExtension/JenkinsClient.cs
+++ b/Jenkins/InedoExtension/JenkinsClient.cs
@@ -153,7 +153,14 @@ namespace Inedo.Extensions.Jenkins
 
         public async Task<List<string>> GetBuildNumbersAsync(string jobName, string branchName = null)
         {
-            string result = await this.GetAsync("job/" + Uri.EscapeUriString(jobName) + "/api/xml?tree=builds[number]").ConfigureAwait(false);
+            string apiUrl = "job/" + Uri.EscapeUriString(jobName);
+            
+            if (!String.IsNullOrEmpty(branchName))
+            {
+                apiUrl += "/job/" + Uri.EscapeUriString(branchName);
+            }
+
+            string result = await this.GetAsync(apiUrl + "/api/xml?tree=builds[number]").ConfigureAwait(false);
             var results = XDocument.Parse(result)
                 .Descendants("number")
                 .Select(n => n.Value)

--- a/Jenkins/InedoExtension/JenkinsClient.cs
+++ b/Jenkins/InedoExtension/JenkinsClient.cs
@@ -301,9 +301,9 @@ namespace Inedo.Extensions.Jenkins
             return this.OpenAsync(GetApiUrl(jobName, branchName, buildNumber, $"artifact/{artifact.RelativePath}"));
         }
 
-        public async Task<int> TriggerBuildAsync(string jobName, string additionalParameters = null)
+        public async Task<int> TriggerBuildAsync(string jobName, string additionalParameters = null, string branchName = null)
         {
-            var url = "/job/" + Uri.EscapeUriString(jobName) + "/build";
+            var url = GetApiUrl(jobName, branchName, null, "build");            
             if (!string.IsNullOrEmpty(additionalParameters))
                 url += "WithParameters?" + additionalParameters;
             return int.Parse(PathEx.GetFileName(await this.PostAsync(url).ConfigureAwait(false)));

--- a/Jenkins/InedoExtension/ListVariableSources/JenkinsBranchNameVariableSource.cs
+++ b/Jenkins/InedoExtension/ListVariableSources/JenkinsBranchNameVariableSource.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Inedo.Documentation;
+using Inedo.Extensibility.Credentials;
+using Inedo.Extensibility.ListVariableSources;
+using Inedo.Extensions.Jenkins.Credentials;
+using Inedo.Serialization;
+using Inedo.Web;
+
+namespace Inedo.Extensions.Jenkins.ListVariableSources
+{
+    [DisplayName("Jenkins Branch Name")]
+    [Description("Build names from a specified job in a Jenkins instance.")]
+    public sealed class JenkinsBranchNameVariableSource : ListVariableSource, IHasCredentials<JenkinsCredentials>
+    {
+        [Persistent]
+        [DisplayName("Credentials")]
+        [TriggerPostBackOnChange]
+        [Required]
+        public string CredentialName { get; set; }
+
+        [Persistent]
+        [DisplayName("Job name")]
+        [SuggestableValue(typeof(JobNameSuggestionProvider))]
+        [Required]
+        public string JobName { get; set; }
+
+        public override async Task<IEnumerable<string>> EnumerateValuesAsync(ValueEnumerationContext context)
+        {
+            var credentials = (JenkinsCredentials)ResourceCredentials.TryCreate(JenkinsCredentials.TypeName, this.CredentialName, environmentId: null, applicationId: context.ProjectId, inheritFromParent: false);
+            if (credentials == null)
+                return Enumerable.Empty<string>();
+
+            var client = new JenkinsClient(credentials, null, default);
+            return await client.GetBranchNamesAsync(this.JobName).ConfigureAwait(false);
+        }
+
+        public override RichDescription GetDescription()
+        {
+            return new RichDescription("Jenkins (", new Hilite(this.CredentialName), ") ", " branches for ", new Hilite(this.JobName), ".");
+        }
+    }
+}

--- a/Jenkins/InedoExtension/ListVariableSources/JenkinsBuildNumberVariableSource.cs
+++ b/Jenkins/InedoExtension/ListVariableSources/JenkinsBuildNumberVariableSource.cs
@@ -27,6 +27,11 @@ namespace Inedo.Extensions.Jenkins.ListVariableSources
         [Required]
         public string JobName { get; set; }
 
+        [Persistent]
+        [DisplayName("Branch name")]
+        [SuggestableValue(typeof(BranchNameSuggestionProvider))]
+        public string BranchName { get; set; }
+
         public override async Task<IEnumerable<string>> EnumerateValuesAsync(ValueEnumerationContext context)
         {
             var credentials = (JenkinsCredentials)ResourceCredentials.TryCreate(JenkinsCredentials.TypeName, this.CredentialName, environmentId: null, applicationId: context.ProjectId, inheritFromParent: false);
@@ -34,7 +39,7 @@ namespace Inedo.Extensions.Jenkins.ListVariableSources
                 return Enumerable.Empty<string>();
 
             var client = new JenkinsClient(credentials, null, default);
-            return await client.GetBuildNumbersAsync(this.JobName).ConfigureAwait(false);
+            return await client.GetBuildNumbersAsync(this.JobName, this.BranchName).ConfigureAwait(false);
         }
 
         public override RichDescription GetDescription()

--- a/Jenkins/InedoExtension/ListVariableSources/JenkinsBuildNumberVariableSource.cs
+++ b/Jenkins/InedoExtension/ListVariableSources/JenkinsBuildNumberVariableSource.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using static Inedo.Extensions.Jenkins.Message;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -44,7 +45,7 @@ namespace Inedo.Extensions.Jenkins.ListVariableSources
 
         public override RichDescription GetDescription()
         {
-            return new RichDescription("Jenkins (", new Hilite(this.CredentialName), ") ", " builds for ", new Hilite(this.JobName), ".");
+            return new RichDescription("Jenkins (", new Hilite(this.CredentialName), ") ", " builds for ", new Hilite(this.JobName), IfHasValue(this.BranchName, " on branch ", new Hilite(this.BranchName)), ".");
         }
     }
 }

--- a/Jenkins/InedoExtension/ListVariableSources/JenkinsBuildNumberVariableSource.cs
+++ b/Jenkins/InedoExtension/ListVariableSources/JenkinsBuildNumberVariableSource.cs
@@ -1,4 +1,4 @@
-﻿using static Inedo.Extensions.Jenkins.Message;
+﻿using static Inedo.Extensions.Jenkins.InlineIf;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/Jenkins/InedoExtension/Message.cs
+++ b/Jenkins/InedoExtension/Message.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Inedo.Extensions.Jenkins
+{
+    public static class Message
+    {
+        public static string IfHasValue(string value, string msg)
+        {
+            if (String.IsNullOrEmpty(value))
+                return String.Empty;
+
+            return msg;
+        }
+
+        public static object IfHasValue(string value, object msg)
+        {
+            if (String.IsNullOrEmpty(value))
+                return null;
+
+            return msg;
+        }
+
+        public static object[] IfHasValue(string value, params object[] msg)
+        {
+            if (String.IsNullOrEmpty(value))
+                return null;
+
+            return msg;
+        }
+    }
+}

--- a/Jenkins/InedoExtension/Operations/DownloadJenkinsArtifactOperation.cs
+++ b/Jenkins/InedoExtension/Operations/DownloadJenkinsArtifactOperation.cs
@@ -136,9 +136,8 @@ namespace Inedo.Extensions.Jenkins.Operations
 
             if (AH.ParseInt(this.BuildNumber) == null)
             {
-                this.LogDebug($"Looking up {this.BuildNumber}...");
+                this.LogInformation($"Build number is not an integer, resolving special build number \"{this.BuildNumber}\"...");
                 this.BuildNumber = await client.GetSpecialBuildNumberAsync(this.JobName, this.BranchName, this.BuildNumber).ConfigureAwait(false);
-                this.LogInformation($"Using Jenkins build number {this.BuildNumber}.");
             }
 
             this.LogInformation($"Downloading artifact from job \"{this.JobName}\"{IfHasValue(this.BranchName, $" on branch \"{this.BranchName}\"")} for build #{this.BuildNumber}...");

--- a/Jenkins/InedoExtension/Operations/DownloadJenkinsArtifactOperation.cs
+++ b/Jenkins/InedoExtension/Operations/DownloadJenkinsArtifactOperation.cs
@@ -195,8 +195,8 @@ namespace Inedo.Extensions.Jenkins.Operations
 
         private sealed class RemoteTemporaryFile : IDisposable
         {
-            private IFileOperationsExecuter fileOps;
-            private ILogSink log;
+            private readonly IFileOperationsExecuter fileOps;
+            private readonly ILogSink log;
 
             public RemoteTemporaryFile(IFileOperationsExecuter fileOps, ILogSink log)
             {

--- a/Jenkins/InedoExtension/Operations/DownloadJenkinsArtifactOperation.cs
+++ b/Jenkins/InedoExtension/Operations/DownloadJenkinsArtifactOperation.cs
@@ -1,4 +1,4 @@
-﻿using static Inedo.Extensions.Jenkins.Message;
+﻿using static Inedo.Extensions.Jenkins.InlineIf;
 using System;
 using System.ComponentModel;
 using System.IO;

--- a/Jenkins/InedoExtension/Operations/DownloadJenkinsArtifactOperation.cs
+++ b/Jenkins/InedoExtension/Operations/DownloadJenkinsArtifactOperation.cs
@@ -33,6 +33,12 @@ namespace Inedo.Extensions.Jenkins.Operations
         [SuggestableValue(typeof(JobNameSuggestionProvider))]
         public string JobName { get; set; }
 
+        [ScriptAlias("Branch")]
+        [DisplayName("Branch name")]
+        [SuggestableValue(typeof(BranchNameSuggestionProvider))]
+        [Description("The branch name is required for a Jenkins multi-branch project, otherwise should be left empty.")]
+        public string BranchName { get; set; }
+
         [ScriptAlias("BuildNumber")]
         [DisplayName("Build number")]
         [DefaultValue("lastSuccessfulBuild")]
@@ -74,7 +80,7 @@ namespace Inedo.Extensions.Jenkins.Operations
 
                 var client = new JenkinsClient(this, this, context.CancellationToken);
 
-                using (var artifact = await client.OpenArtifactAsync(this.JobName, this.BuildNumber).ConfigureAwait(false))
+                using (var artifact = await client.OpenArtifactAsync(this.JobName, this.BranchName, this.BuildNumber).ConfigureAwait(false))
                 using (var tempFileStream = await tempFile.OpenAsync().ConfigureAwait(false))
                 {
                     await artifact.Content.CopyToAsync(tempFileStream).ConfigureAwait(false);
@@ -115,7 +121,7 @@ namespace Inedo.Extensions.Jenkins.Operations
 
             var client = new JenkinsClient(this, this, context.CancellationToken);
 
-            using (var singleArtifact = await client.OpenSingleArtifactAsync(this.JobName, this.BuildNumber, artifact).ConfigureAwait(false))
+            using (var singleArtifact = await client.OpenSingleArtifactAsync(this.JobName, this.BranchName, this.BuildNumber, artifact).ConfigureAwait(false))
             using (var tempFileStream = await fileOps.OpenFileAsync(fileName, FileMode.Create, FileAccess.Write).ConfigureAwait(false))
             {
                 await singleArtifact.Content.CopyToAsync(tempFileStream).ConfigureAwait(false);
@@ -130,7 +136,7 @@ namespace Inedo.Extensions.Jenkins.Operations
             if (AH.ParseInt(this.BuildNumber) == null)
             {
                 this.LogDebug("Looking up {0}...", this.BuildNumber);
-                this.BuildNumber = await client.GetSpecialBuildNumberAsync(this.JobName, this.BuildNumber).ConfigureAwait(false);
+                this.BuildNumber = await client.GetSpecialBuildNumberAsync(this.JobName, this.BranchName, this.BuildNumber).ConfigureAwait(false);
                 this.LogInformation($"Using Jenkins build number {this.BuildNumber}.");
             }
 
@@ -141,7 +147,7 @@ namespace Inedo.Extensions.Jenkins.Operations
             }
             else
             {
-                var artifacts = await client.GetBuildArtifactsAsync(this.JobName, this.BuildNumber).ConfigureAwait(false);
+                var artifacts = await client.GetBuildArtifactsAsync(this.JobName, this.BranchName, this.BuildNumber).ConfigureAwait(false);
                 this.LogDebug($"Build contains {artifacts.Count} build artifacts.");
                 if (artifacts.Count == 0)
                 {

--- a/Jenkins/InedoExtension/Operations/IQueueJenkinsBuildArgs.cs
+++ b/Jenkins/InedoExtension/Operations/IQueueJenkinsBuildArgs.cs
@@ -6,6 +6,7 @@ namespace Inedo.Extensions.Jenkins.Operations
     internal interface IQueueJenkinsBuildArgs : ILogSink, IJenkinsConnectionInfo
     {
         string JobName { get; set; }
+        string BranchName { get; set; }
         string AdditionalParameters { get; set; }
         bool WaitForStart { get; set; }
         bool WaitForCompletion { get; set; }

--- a/Jenkins/InedoExtension/Operations/ImportJenkinsArtifactOperation.cs
+++ b/Jenkins/InedoExtension/Operations/ImportJenkinsArtifactOperation.cs
@@ -43,6 +43,7 @@ namespace Inedo.Extensions.Jenkins.Operations
         [Required]
         [ScriptAlias("Artifact")]
         [DisplayName("Artifact name")]
+        [DefaultValue("archive.zip")]
         [Description("The name of the artifact in BuildMaster once it is captured from the {jenkinsUrl}/job/{jobName}/{buildNumber}/artifact/*zip*/archive.zip endpoint.")]
         public string ArtifactName { get; set; }
 

--- a/Jenkins/InedoExtension/Operations/ImportJenkinsArtifactOperation.cs
+++ b/Jenkins/InedoExtension/Operations/ImportJenkinsArtifactOperation.cs
@@ -1,4 +1,4 @@
-﻿using static Inedo.Extensions.Jenkins.Message;
+﻿using static Inedo.Extensions.Jenkins.InlineIf;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;

--- a/Jenkins/InedoExtension/Operations/ImportJenkinsArtifactOperation.cs
+++ b/Jenkins/InedoExtension/Operations/ImportJenkinsArtifactOperation.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using static Inedo.Extensions.Jenkins.Message;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using Inedo.Documentation;
@@ -43,7 +44,7 @@ namespace Inedo.Extensions.Jenkins.Operations
         [Required]
         [ScriptAlias("Artifact")]
         [DisplayName("Artifact name")]
-        [DefaultValue("archive.zip")]
+        [PlaceholderText("e.g. archive.zip")]
         [Description("The name of the artifact in BuildMaster once it is captured from the {jenkinsUrl}/job/{jobName}/{buildNumber}/artifact/*zip*/archive.zip endpoint.")]
         public string ArtifactName { get; set; }
 
@@ -69,23 +70,12 @@ namespace Inedo.Extensions.Jenkins.Operations
 
         protected override ExtendedRichDescription GetDescription(IOperationConfiguration config)
         {
-            string buildNumber = config[nameof(this.BuildNumber)];
+            string jobName = config[nameof(this.JobName)];
+            string artifactName = config[nameof(this.ArtifactName)];
 
-            var desc = new List<object>();
-            desc.Add("of build ");
-            desc.Add(AH.ParseInt(buildNumber) != null ? "#" : "");
-            desc.Add(new Hilite(buildNumber));
-            if (!string.IsNullOrEmpty(this.BranchName))
-            {
-                desc.Add(" on  branch ");
-                desc.Add(new Hilite(this.BranchName));
-            }
-            desc.Add(" for job ");
-            desc.Add(new Hilite(config[nameof(this.JobName)]));
-            
             return new ExtendedRichDescription(
-                new RichDescription("Import Jenkins ", new Hilite(config[nameof(this.ArtifactName)]), " Artifact "),
-                new RichDescription(desc.ToArray())
+                new RichDescription("Import Jenkins Artifact ", new Hilite(artifactName)),
+                new RichDescription("from job ", new Hilite(jobName))
             );
         }
     }

--- a/Jenkins/InedoExtension/Operations/QueueJenkinsBuildOperation.cs
+++ b/Jenkins/InedoExtension/Operations/QueueJenkinsBuildOperation.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using static Inedo.Extensions.Jenkins.Message;
+using System;
 using System.ComponentModel;
 using System.IO;
 using System.Threading;
@@ -96,19 +97,21 @@ namespace Inedo.Extensions.Jenkins.Operations
 
         protected override ExtendedRichDescription GetDescription(IOperationConfiguration config)
         {
+            string branchName = config[nameof(this.BranchName)];
+
             return new ExtendedRichDescription(
                 new RichDescription("Queue Jenkins Build"),
                 new RichDescription(
-                    "for job ",
-                    new Hilite(config[nameof(this.JobName)])
+                    "for job ", new Hilite(config[nameof(this.JobName)]),
+                    IfHasValue(branchName, " on branch ", new Hilite(branchName))
                 )
             );
         }
 
         private static async Task QueueBuildAsync(IQueueJenkinsBuildArgs args, CancellationToken cancellationToken)
         {
-            args.LogInformation("Queueing build in Jenkins...");
-
+            args.LogInformation($"Queueing build for job \"{args.JobName}\"{IfHasValue(args.BranchName, $" on branch \"{args.BranchName}\"")}...");
+            
             var client = new JenkinsClient(args, args, cancellationToken);
 
             var queueItem = await client.TriggerBuildAsync(args.JobName, args.BranchName, args.AdditionalParameters).ConfigureAwait(false);

--- a/Jenkins/InedoExtension/Operations/QueueJenkinsBuildOperation.cs
+++ b/Jenkins/InedoExtension/Operations/QueueJenkinsBuildOperation.cs
@@ -1,4 +1,4 @@
-﻿using static Inedo.Extensions.Jenkins.Message;
+﻿using static Inedo.Extensions.Jenkins.InlineIf;
 using System;
 using System.ComponentModel;
 using System.IO;

--- a/Jenkins/InedoExtension/Operations/QueueJenkinsBuildOperation.cs
+++ b/Jenkins/InedoExtension/Operations/QueueJenkinsBuildOperation.cs
@@ -31,6 +31,12 @@ namespace Inedo.Extensions.Jenkins.Operations
         [SuggestableValue(typeof(JobNameSuggestionProvider))]
         public string JobName { get; set; }
 
+        [ScriptAlias("Branch")]
+        [DisplayName("Branch name")]
+        [SuggestableValue(typeof(BranchNameSuggestionProvider))]
+        [Description("The branch name is required for a Jenkins multi-branch project, otherwise should be left empty.")]
+        public string BranchName { get; set; }
+
         [Category("Advanced")]
         [ScriptAlias("AdditionalParameters")]
         [DisplayName("Additional parameters")]
@@ -105,7 +111,7 @@ namespace Inedo.Extensions.Jenkins.Operations
 
             var client = new JenkinsClient(args, args, cancellationToken);
 
-            var queueItem = await client.TriggerBuildAsync(args.JobName, args.AdditionalParameters).ConfigureAwait(false);
+            var queueItem = await client.TriggerBuildAsync(args.JobName, args.BranchName, args.AdditionalParameters).ConfigureAwait(false);
 
             args.LogInformation($"Jenkins build queued successfully.");
             args.LogDebug($"Queue item number: {queueItem}");
@@ -149,7 +155,7 @@ namespace Inedo.Extensions.Jenkins.Operations
                 while (true)
                 {
                     await Task.Delay(2 * 1000, cancellationToken).ConfigureAwait(false);
-                    build = await client.GetBuildInfoAsync(args.JobName, buildNumber).ConfigureAwait(false);
+                    build = await client.GetBuildInfoAsync(args.JobName, args.BranchName, buildNumber).ConfigureAwait(false);
                     if (build == null)
                     {
                         args.LogDebug("Build information was not returned.");
@@ -199,6 +205,7 @@ namespace Inedo.Extensions.Jenkins.Operations
         private sealed class QueueBuildRemoteJob : RemoteJob, IQueueJenkinsBuildArgs
         {
             public string JobName { get; set; }
+            public string BranchName { get; set; }
             public string AdditionalParameters { get; set; }
             public bool WaitForStart { get; set; }
             public bool WaitForCompletion { get; set; }
@@ -217,6 +224,7 @@ namespace Inedo.Extensions.Jenkins.Operations
             public QueueBuildRemoteJob(QueueJenkinsBuildOperation operation)
             {
                 this.JobName = operation.JobName;
+                this.BranchName = operation.BranchName;
                 this.AdditionalParameters = operation.AdditionalParameters;
                 this.WaitForStart = operation.WaitForStart;
                 this.WaitForCompletion = operation.WaitForCompletion;

--- a/Jenkins/InedoExtension/SuggestionProviders/ArtifactNameSuggestionProvider.cs
+++ b/Jenkins/InedoExtension/SuggestionProviders/ArtifactNameSuggestionProvider.cs
@@ -16,10 +16,10 @@ namespace Inedo.Extensions.Jenkins
         {
             var credentialName = config["CredentialName"];
             var jobName = config["JobName"];
-            var branchName = config["BranchName"];
             if (string.IsNullOrEmpty(credentialName) || string.IsNullOrEmpty(jobName))
                 return Enumerable.Empty<string>();
 
+            var branchName = config["BranchName"];
             string buildNumber = AH.CoalesceString(config["BuildNumber"], "lastSuccessfulBuild");
 
             int? projectId = AH.ParseInt(AH.CoalesceString(config["ProjectId"], config["ApplicationId"]));
@@ -32,7 +32,7 @@ namespace Inedo.Extensions.Jenkins
             using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
             {
                 var client = new JenkinsClient(credentials, null, cts.Token);
-                return (await client.GetBuildArtifactsAsync(jobName, buildNumber, branchName))
+                return (await client.GetBuildArtifactsAsync(jobName, branchName, buildNumber))
                     .Select(a => a.RelativePath)
                     .ToList();
             }

--- a/Jenkins/InedoExtension/SuggestionProviders/ArtifactNameSuggestionProvider.cs
+++ b/Jenkins/InedoExtension/SuggestionProviders/ArtifactNameSuggestionProvider.cs
@@ -16,6 +16,7 @@ namespace Inedo.Extensions.Jenkins
         {
             var credentialName = config["CredentialName"];
             var jobName = config["JobName"];
+            var branchName = config["BranchName"];
             if (string.IsNullOrEmpty(credentialName) || string.IsNullOrEmpty(jobName))
                 return Enumerable.Empty<string>();
 
@@ -31,7 +32,7 @@ namespace Inedo.Extensions.Jenkins
             using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
             {
                 var client = new JenkinsClient(credentials, null, cts.Token);
-                return (await client.GetBuildArtifactsAsync(jobName, buildNumber))
+                return (await client.GetBuildArtifactsAsync(jobName, buildNumber, branchName))
                     .Select(a => a.RelativePath)
                     .ToList();
             }

--- a/Jenkins/InedoExtension/SuggestionProviders/BranchNameSuggestionProvider.cs
+++ b/Jenkins/InedoExtension/SuggestionProviders/BranchNameSuggestionProvider.cs
@@ -29,7 +29,7 @@ namespace Inedo.Extensions.Jenkins
             using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
             {
                 var client = new JenkinsClient(credentials, null, cts.Token);
-                return await client.GetBuildNumbersAsync(jobName).ConfigureAwait(false);
+                return await client.GetBranchNamesAsync(jobName).ConfigureAwait(false);
             }
         }
     }

--- a/Jenkins/InedoExtension/SuggestionProviders/BranchNameSuggestionProvider.cs
+++ b/Jenkins/InedoExtension/SuggestionProviders/BranchNameSuggestionProvider.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Inedo.Extensibility;
+using Inedo.Extensibility.Credentials;
+using Inedo.Extensions.Jenkins.Credentials;
+using Inedo.Web;
+
+namespace Inedo.Extensions.Jenkins
+{
+    internal sealed class BranchNameSuggestionProvider : ISuggestionProvider
+    {
+        public async Task<IEnumerable<string>> GetSuggestionsAsync(IComponentConfiguration config)
+        {
+            var credentialName = config["CredentialName"];
+            var jobName = config["JobName"];
+            if (string.IsNullOrEmpty(credentialName) || string.IsNullOrEmpty(jobName))
+                return Enumerable.Empty<string>();
+
+            int? projectId = AH.ParseInt(AH.CoalesceString(config["ProjectId"], config["ApplicationId"]));
+            int? environmentId = AH.ParseInt(config["EnvironmentId"]);
+
+            var credentials = (JenkinsCredentials)ResourceCredentials.TryCreate(JenkinsCredentials.TypeName, credentialName, environmentId: environmentId, applicationId: projectId, inheritFromParent: false);
+            if (credentials == null)
+                return Enumerable.Empty<string>();
+
+            using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
+            {
+                var client = new JenkinsClient(credentials, null, cts.Token);
+                return await client.GetBuildNumbersAsync(jobName).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/Jenkins/InedoExtension/SuggestionProviders/BuildNumberSuggestionProvider.cs
+++ b/Jenkins/InedoExtension/SuggestionProviders/BuildNumberSuggestionProvider.cs
@@ -16,10 +16,10 @@ namespace Inedo.Extensions.Jenkins
         {
             var credentialName = config["CredentialName"];
             var jobName = config["JobName"];
-            var branchName = config["BranchName"];
             if (string.IsNullOrEmpty(credentialName) || string.IsNullOrEmpty(jobName))
                 return Enumerable.Empty<string>();
 
+            var branchName = config["BranchName"];
             int? projectId = AH.ParseInt(AH.CoalesceString(config["ProjectId"], config["ApplicationId"]));
             int? environmentId = AH.ParseInt(config["EnvironmentId"]);
 

--- a/Jenkins/InedoExtension/SuggestionProviders/BuildNumberSuggestionProvider.cs
+++ b/Jenkins/InedoExtension/SuggestionProviders/BuildNumberSuggestionProvider.cs
@@ -16,6 +16,7 @@ namespace Inedo.Extensions.Jenkins
         {
             var credentialName = config["CredentialName"];
             var jobName = config["JobName"];
+            var branchName = config["BranchName"];
             if (string.IsNullOrEmpty(credentialName) || string.IsNullOrEmpty(jobName))
                 return Enumerable.Empty<string>();
 
@@ -29,7 +30,7 @@ namespace Inedo.Extensions.Jenkins
             using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
             {
                 var client = new JenkinsClient(credentials, null, cts.Token);
-                return await client.GetBuildNumbersAsync(jobName).ConfigureAwait(false);
+                return await client.GetBuildNumbersAsync(jobName, branchName).ConfigureAwait(false);
             }
         }
     }

--- a/Jenkins/InedoExtension/VariableFunctions/GetJenkinsBranchNameVariableFunction.cs
+++ b/Jenkins/InedoExtension/VariableFunctions/GetJenkinsBranchNameVariableFunction.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Security;
+using Inedo.Documentation;
+using Inedo.ExecutionEngine.Executer;
+using Inedo.Extensibility;
+using Inedo.Extensibility.Credentials;
+using Inedo.Extensibility.VariableFunctions;
+using Inedo.Extensions.Jenkins.Credentials;
+using Inedo.Serialization;
+
+namespace Inedo.Extensions.Jenkins.VariableFunctions
+{
+    [ScriptAlias("JenkinsBranchName")]
+    [Description("Returns a empty string in the event there is no overriding variable")]
+    [Example(@"# 
+JenkinsBranchName
+")]
+    public sealed class GetJenkinsBranchNameVariableFunction : ScalarVariableFunction
+    {
+        
+        protected override object EvaluateScalar(IVariableFunctionContext context)
+        {
+            return String.Empty;
+        }
+    }
+}

--- a/Jenkins/InedoExtension/VariableFunctions/GetJenkinsUrlVariableFunction.cs
+++ b/Jenkins/InedoExtension/VariableFunctions/GetJenkinsUrlVariableFunction.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Security;
+using Inedo.Documentation;
+using Inedo.ExecutionEngine.Executer;
+using Inedo.Extensibility;
+using Inedo.Extensibility.Credentials;
+using Inedo.Extensibility.VariableFunctions;
+using Inedo.Extensions.Jenkins.Credentials;
+using Inedo.Serialization;
+
+namespace Inedo.Extensions.Jenkins.VariableFunctions
+{
+    [ScriptAlias("JenkinsUrl")]
+    [ScriptAlias("GetJenkinsUrl")]
+    [Description("The url for the Jenkins Build")]
+    //[Tag(Tags.Credentials)]
+    [Example(@"# 
+$GetJenkinsBuildUrl(Jenkins, $JenkinsJobName);
+$GetJenkinsBuildUrl(Jenkins, $JenkinsJobName, $JenkinsBuildNumber, $JenkinsBranchName);
+")]
+    public sealed class GetJenkinsUrlVariableFunction : ScalarVariableFunction
+    {
+        [VariableFunctionParameter(0)]
+        [ScriptAlias("credential")]
+        [Description("The name of the credential to read, optionally prefixed with the type name of the credential separated by the scope resolution operator (i.e. ::).")]
+        public string CredentialName { get; set; }
+
+        [VariableFunctionParameter(1)]
+        [ScriptAlias("jobName")]
+        [Description("The Jenkins job name.")]
+        public string JobName { get; set; }
+
+        [VariableFunctionParameter(2, Optional = true)]
+        [ScriptAlias("buildNumber")]
+        [Description("The Jenkins build number.")]
+        public string BuildNumber { get; set; } = null;
+
+        [VariableFunctionParameter(3, Optional = true)
+        [ScriptAlias("branchName")]
+        [Description("The Jenkins branch name.")]
+        public string BranchName { get; set; } = null;
+
+        protected override object EvaluateScalar(IVariableFunctionContext context)
+        {
+            var name = Inedo.Extensibility.Credentials.CredentialName.TryParse(this.CredentialName);
+            if (name == null)
+                throw new ExecutionFailureException(true, $"The specified credential name \"{this.CredentialName}\" is invalid.");
+
+            // need to resolve credential type name if it's not specified with the scope resolution operator
+            if (name.TypeName == null)
+            {
+                var types = (from c in SDK.GetCredentials()
+                             where string.Equals(c.Name, name.Name, StringComparison.OrdinalIgnoreCase)
+                             select c.TypeName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                if (types.Count == 0)
+                    throw new ExecutionFailureException(true, $"There are no credentials named \"{name.Name}\" found in the system.");
+                if (types.Count > 1)
+                    throw new ExecutionFailureException(true, $"There are multiple credential types with the name \"{name.Name}\" found in the system. Use the scope resolution operator (i.e. ::) to specify a type, for example: UsernamePassword::{name.Name}");
+
+                name = new CredentialName(types.First(), name.Name);
+            }
+
+            var credential = ResourceCredentials.TryCreate(name.TypeName, name.Name, environmentId: context.EnvironmentId, applicationId: context.ProjectId, inheritFromParent: true);
+
+            if (credential == null)
+                throw new ExecutionFailureException($"Could not find a {name.TypeName} Resource Credentials named \"{name.Name}\"; this error may occur if you renamed a credential, or the application or environment in context does not match any existing credentials. To resolve, edit this item, property, or operation's configuration, ensure a valid credential for the application/environment in context is selected, and then save.");
+
+            if (!(credential is JenkinsCredentials))
+            {
+                throw new ExecutionFailureException($"Resource Credential \"{name.Name}\" is not a Jenkins Credential.");
+            }
+
+            var jenkins = (JenkinsCredentials)credential;
+
+            UriBuilder uri = new UriBuilder(jenkins.ServerUrl)
+            {
+                Path = JenkinsClient.GetPath(this.JobName, this.BranchName, this.BuildNumber)
+            };
+
+            return uri.ToString();
+        }
+    }
+}

--- a/Jenkins/InedoExtension/VariableFunctions/GetJenkinsUrlVariableFunction.cs
+++ b/Jenkins/InedoExtension/VariableFunctions/GetJenkinsUrlVariableFunction.cs
@@ -15,7 +15,6 @@ namespace Inedo.Extensions.Jenkins.VariableFunctions
     [ScriptAlias("JenkinsUrl")]
     [ScriptAlias("GetJenkinsUrl")]
     [Description("The url for the Jenkins Build")]
-    //[Tag(Tags.Credentials)]
     [Example(@"# 
 $GetJenkinsBuildUrl(Jenkins, $JenkinsJobName);
 $GetJenkinsBuildUrl(Jenkins, $JenkinsJobName, $JenkinsBuildNumber, $JenkinsBranchName);
@@ -37,7 +36,7 @@ $GetJenkinsBuildUrl(Jenkins, $JenkinsJobName, $JenkinsBuildNumber, $JenkinsBranc
         [Description("The Jenkins build number.")]
         public string BuildNumber { get; set; } = null;
 
-        [VariableFunctionParameter(3, Optional = true)
+        [VariableFunctionParameter(3, Optional = true)]
         [ScriptAlias("branchName")]
         [Description("The Jenkins branch name.")]
         public string BranchName { get; set; } = null;

--- a/Jenkins/InedoExtensionTests/InedoExtensionTests.csproj
+++ b/Jenkins/InedoExtensionTests/InedoExtensionTests.csproj
@@ -41,34 +41,38 @@
   <ItemGroup>
     <Reference Include="Inedo.Agents.Client, Version=1000.0.0.0, Culture=neutral, PublicKeyToken=9de986a2f8db80fc, processorArchitecture=MSIL">
       <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\Inedo.Agents.Client.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Inedo.ExecutionEngine, Version=1000.0.0.0, Culture=neutral, PublicKeyToken=68703f0e52007e75, processorArchitecture=MSIL">
       <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\Inedo.ExecutionEngine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Inedo.SDK, Version=1.3.0.0, Culture=neutral, PublicKeyToken=29fae5dec3001603, processorArchitecture=MSIL">
       <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\Inedo.SDK.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="InedoLib, Version=1000.0.0.0, Culture=neutral, PublicKeyToken=112cfb71329714a6, processorArchitecture=MSIL">
       <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\InedoLib.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Net.Http" />
+    <Reference Include="System">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http">
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -90,7 +94,7 @@
     <ProjectReference Include="..\InedoExtension\InedoExtension.csproj">
       <Project>{9421990C-1CE6-41AF-BE1F-69C0E368952C}</Project>
       <Name>InedoExtension</Name>
-      <Private>False</Private>
+      <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
   <Choose>

--- a/Jenkins/InedoExtensionTests/InedoExtensionTests.csproj
+++ b/Jenkins/InedoExtensionTests/InedoExtensionTests.csproj
@@ -61,6 +61,7 @@
       <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/Jenkins/InedoExtensionTests/InedoExtensionTests.csproj
+++ b/Jenkins/InedoExtensionTests/InedoExtensionTests.csproj
@@ -74,6 +74,7 @@
   <ItemGroup>
     <Compile Include="JenkinsClientTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TempDir.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Jenkins/InedoExtensionTests/InedoExtensionTests.csproj
+++ b/Jenkins/InedoExtensionTests/InedoExtensionTests.csproj
@@ -1,0 +1,121 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DA60C56F-4EEC-4CCC-806D-35F1EA4975CD}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>InedoExtensionTests</RootNamespace>
+    <AssemblyName>InedoExtensionTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Inedo.Agents.Client, Version=1000.0.0.0, Culture=neutral, PublicKeyToken=9de986a2f8db80fc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\Inedo.Agents.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Inedo.ExecutionEngine, Version=1000.0.0.0, Culture=neutral, PublicKeyToken=68703f0e52007e75, processorArchitecture=MSIL">
+      <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\Inedo.ExecutionEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="Inedo.SDK, Version=1.3.0.0, Culture=neutral, PublicKeyToken=29fae5dec3001603, processorArchitecture=MSIL">
+      <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\Inedo.SDK.dll</HintPath>
+    </Reference>
+    <Reference Include="InedoLib, Version=1000.0.0.0, Culture=neutral, PublicKeyToken=112cfb71329714a6, processorArchitecture=MSIL">
+      <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\InedoLib.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="JenkinsClientTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\InedoExtension\InedoExtension.csproj">
+      <Project>{9421990C-1CE6-41AF-BE1F-69C0E368952C}</Project>
+      <Name>InedoExtension</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Jenkins/InedoExtensionTests/InedoExtensionTests.csproj
+++ b/Jenkins/InedoExtensionTests/InedoExtensionTests.csproj
@@ -41,24 +41,31 @@
   <ItemGroup>
     <Reference Include="Inedo.Agents.Client, Version=1000.0.0.0, Culture=neutral, PublicKeyToken=9de986a2f8db80fc, processorArchitecture=MSIL">
       <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\Inedo.Agents.Client.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Inedo.ExecutionEngine, Version=1000.0.0.0, Culture=neutral, PublicKeyToken=68703f0e52007e75, processorArchitecture=MSIL">
       <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\Inedo.ExecutionEngine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Inedo.SDK, Version=1.3.0.0, Culture=neutral, PublicKeyToken=29fae5dec3001603, processorArchitecture=MSIL">
       <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\Inedo.SDK.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="InedoLib, Version=1000.0.0.0, Culture=neutral, PublicKeyToken=112cfb71329714a6, processorArchitecture=MSIL">
       <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\InedoLib.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Inedo.SDK.1.3.0\lib\net452\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />
@@ -83,6 +90,7 @@
     <ProjectReference Include="..\InedoExtension\InedoExtension.csproj">
       <Project>{9421990C-1CE6-41AF-BE1F-69C0E368952C}</Project>
       <Name>InedoExtension</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <Choose>

--- a/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
+++ b/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
@@ -31,14 +31,14 @@ namespace Inedo.Extensions.Jenkins.Tests
             { JobType.FreeStyleProject, "demo-freestyle"},
             { JobType.WorkflowJob, "demo-pipeline" },
             { JobType.MatrixProject, "demo-multi-config" },
-            { JobType.WorkflowMultiBranchProject, "demo-multibranch" }
+            { JobType.WorkflowMultiBranchProject, "BuildMaster multibranch" }
         };
 
         public JenkinsCredentials ResourceCredentials => new JenkinsCredentials()
         {
-            ServerUrl = "http://inedo:8080",
+            ServerUrl = "http://localhost:8080",
             UserName = "admin",
-            Password = AH.CreateSecureString("11b54857bc1426530dc818fcbeb4f77d34")
+            Password = AH.CreateSecureString("11643bbca2608d05f20b6e78fb8b01186e")
         };
 
         private string GetTestBranchName(JobType jobType)

--- a/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
+++ b/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
@@ -290,8 +290,8 @@ namespace Inedo.Extensions.Jenkins.Tests
                     var queueTask = Task.Run<JenkinsQueueItem>(async () => await client.GetQueuedBuildInfoAsync(queueId));
                     var queueItem = queueTask.Result();
 
-                    Assert.IsTrue(queueItem.BuildNumber == null, $"queueItem should be populated for {job.Key} job {job.Value}");
-                    Assert.IsTrue(queueItem.WaitReason.Contains("quiet period"), $"queueItem should be populated for {job.Key} job {job.Value}");
+                    Assert.IsTrue(queueItem.BuildNumber == null, $"BuildNumber should be null for {job.Key} job {job.Value}");
+                    Assert.IsTrue(queueItem.WaitReason.Contains("quiet period"), $"WaitReason should contain 'quiet period' for {job.Key} job {job.Value}");
                 }
             }
         }

--- a/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
+++ b/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
@@ -116,7 +116,7 @@ namespace Inedo.Extensions.Jenkins.Tests
             using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
             {
                 var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
-                var task = Task.Run<List<string>>(async () => await client.GetBuildNumbersAsync(JobNames[JobType.WorkflowMultiBranchProject]).ConfigureAwait(false));
+                var task = Task.Run<List<string>>(async () => await client.GetBuildNumbersAsync(JobNames[JobType.WorkflowMultiBranchProject], null).ConfigureAwait(false));
                 task.WaitAndUnwrapExceptions();
             }
         }
@@ -129,10 +129,10 @@ namespace Inedo.Extensions.Jenkins.Tests
                 using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
                 {
                     var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
-                    var task = Task.Run<string>(async () => await client.GetSpecialBuildNumberAsync(job.Value, "lastSuccessfulBuild", GetTestBranchName(job.Key)).ConfigureAwait(false));
+                    var task = Task.Run<string>(async () => await client.GetSpecialBuildNumberAsync(job.Value, GetTestBranchName(job.Key), "lastSuccessfulBuild").ConfigureAwait(false));
                     var build = task.Result;
 
-                    Assert.IsTrue(long.TryParse(build, out long n), $"Special build number should be converted to actual build number for {job.Key} job {job.Value}");
+                    Assert.IsTrue(AH.ParseInt(build).HasValue, $"Special build number should be converted to actual build number for {job.Key} job {job.Value}");
                 }
             }
         }
@@ -143,7 +143,7 @@ namespace Inedo.Extensions.Jenkins.Tests
             using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
             {
                 var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
-                var task = Task.Run<string>(async () => await client.GetSpecialBuildNumberAsync(JobNames[JobType.FreeStyleProject], "invalidBuild").ConfigureAwait(false));
+                var task = Task.Run<string>(async () => await client.GetSpecialBuildNumberAsync(JobNames[JobType.FreeStyleProject], null, "invalidBuild").ConfigureAwait(false));
                 var build = task.Result;
                 
                 Assert.IsTrue(build == null, "No build for special build number should return null");
@@ -158,7 +158,7 @@ namespace Inedo.Extensions.Jenkins.Tests
                 using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
                 {
                     var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
-                    var task = Task.Run<JenkinsBuild>(async () => await client.GetBuildInfoAsync(job.Value, "lastSuccessfulBuild", GetTestBranchName(job.Key)).ConfigureAwait(false));
+                    var task = Task.Run<JenkinsBuild>(async () => await client.GetBuildInfoAsync(job.Value, GetTestBranchName(job.Key), "lastSuccessfulBuild").ConfigureAwait(false));
                     var build = task.Result;
 
                     Assert.IsFalse(build.Building, $"Build should be complete for {job.Key} job {job.Value}");
@@ -178,7 +178,7 @@ namespace Inedo.Extensions.Jenkins.Tests
                 using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
                 {
                     var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
-                    var task = Task.Run<List<JenkinsBuildArtifact>>(async () => await client.GetBuildArtifactsAsync(job.Value, "lastSuccessfulBuild", GetTestBranchName(job.Key)).ConfigureAwait(false));
+                    var task = Task.Run<List<JenkinsBuildArtifact>>(async () => await client.GetBuildArtifactsAsync(job.Value, GetTestBranchName(job.Key), "lastSuccessfulBuild").ConfigureAwait(false));
                     var artifacts = task.Result;
 
                     Assert.IsTrue(artifacts.Count > 0, $"Build should contain one or more artifacts for {job.Key} job {job.Value}");
@@ -202,7 +202,7 @@ namespace Inedo.Extensions.Jenkins.Tests
                     Assert.IsFalse(File.Exists(zipFileName), $"Archive.zip should not exist prior to download for {job.Key} job {job.Value}");
 
                     var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
-                    var task = Task.Run(async () => await client.DownloadArtifactAsync(job.Value, "lastSuccessfulBuild", zipFileName, GetTestBranchName(job.Key)).ConfigureAwait(false));
+                    var task = Task.Run(async () => await client.DownloadArtifactAsync(job.Value, GetTestBranchName(job.Key), "lastSuccessfulBuild", zipFileName).ConfigureAwait(false));
                     task.WaitAndUnwrapExceptions();
 
                     Assert.IsTrue(File.Exists(zipFileName), $"Archive.zip should be downloaded for {job.Key} job {job.Value}");
@@ -227,10 +227,10 @@ namespace Inedo.Extensions.Jenkins.Tests
 
                     var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
 
-                    var artifactTask = Task.Run<List<JenkinsBuildArtifact>>(async () => await client.GetBuildArtifactsAsync(job.Value, "lastSuccessfulBuild", GetTestBranchName(job.Key)).ConfigureAwait(false));
+                    var artifactTask = Task.Run<List<JenkinsBuildArtifact>>(async () => await client.GetBuildArtifactsAsync(job.Value, GetTestBranchName(job.Key), "lastSuccessfulBuild").ConfigureAwait(false));
                     var artifacts = artifactTask.Result;
 
-                    var task = Task.Run(async () => await client.DownloadSingleArtifactAsync(job.Value, "lastSuccessfulBuild", zipFileName, artifacts[0], GetTestBranchName(job.Key)).ConfigureAwait(false));
+                    var task = Task.Run(async () => await client.DownloadSingleArtifactAsync(job.Value, GetTestBranchName(job.Key), "lastSuccessfulBuild", zipFileName, artifacts[0]).ConfigureAwait(false));
                     task.WaitAndUnwrapExceptions();
 
                     Assert.IsTrue(File.Exists(zipFileName), $"Archive.zip should be downloaded for {job.Key} job {job.Value}");
@@ -251,7 +251,7 @@ namespace Inedo.Extensions.Jenkins.Tests
                 using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
                 {
                     var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
-                    var task = Task.Run<OpenArtifact>(async () => await client.OpenArtifactAsync(job.Value, "lastSuccessfulBuild", GetTestBranchName(job.Key)).ConfigureAwait(false));
+                    var task = Task.Run<OpenArtifact>(async () => await client.OpenArtifactAsync(job.Value, GetTestBranchName(job.Key), "lastSuccessfulBuild").ConfigureAwait(false));
                     var openArtifact = task.Result();
 
                     Assert.IsTrue(openArtifact.Content.Length > 0, $"Content should be downloaded for {job.Key} job {job.Value}");
@@ -272,10 +272,10 @@ namespace Inedo.Extensions.Jenkins.Tests
                 {
                     var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
 
-                    var artifactTask = Task.Run<List<JenkinsBuildArtifact>>(async () => await client.GetBuildArtifactsAsync(job.Value, "lastSuccessfulBuild", GetTestBranchName(job.Key)).ConfigureAwait(false));
+                    var artifactTask = Task.Run<List<JenkinsBuildArtifact>>(async () => await client.GetBuildArtifactsAsync(job.Value, GetTestBranchName(job.Key), "lastSuccessfulBuild").ConfigureAwait(false));
                     var artifacts = artifactTask.Result;
 
-                    var task = Task.Run<OpenArtifact>(async () => await client.OpenSingleArtifactAsync(job.Value, "lastSuccessfulBuild", artifacts[0], GetTestBranchName(job.Key)).ConfigureAwait(false));
+                    var task = Task.Run<OpenArtifact>(async () => await client.OpenSingleArtifactAsync(job.Value, "lastSuccessfulBuild", GetTestBranchName(job.Key), artifacts[0]).ConfigureAwait(false));
                     var openArtifact = task.Result();
 
                     Assert.IsTrue(openArtifact.Content.Length > 0, $"Content should be downloaded for {job.Key} job {job.Value}");
@@ -292,7 +292,7 @@ namespace Inedo.Extensions.Jenkins.Tests
                 {
                     var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
                     
-                    var triggerTask = Task.Run<int>(async () => await client.TriggerBuildAsync(job.Value, null, GetTestBranchName(job.Key)).ConfigureAwait(false));
+                    var triggerTask = Task.Run<int>(async () => await client.TriggerBuildAsync(job.Value, GetTestBranchName(job.Key), null).ConfigureAwait(false));
                     var queueId = triggerTask.Result();
 
                     Assert.IsTrue(queueId > 0, $"queueId should be greater than zero for {job.Key} job {job.Value}");

--- a/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
+++ b/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
@@ -58,7 +58,7 @@ namespace Inedo.Extensions.Jenkins.Tests
         }
 
         [TestMethod()]
-        public void GetBuildNumbers_ExcludingMultiBranchJob()
+        public void GetBuildNumbers()
         {
             foreach (var job in JobNames)
             {
@@ -154,7 +154,7 @@ namespace Inedo.Extensions.Jenkins.Tests
 
                     if (job.Key == JobType.MatrixProject)
                     {
-                        //TODO Add matix support?
+                        // Matrix not supported
                         Assert.AreEqual(artifacts.Count, 0, $"Not currently supported for {job.Key} job {job.Value}");
                     }
                     else
@@ -203,5 +203,14 @@ namespace Inedo.Extensions.Jenkins.Tests
                 Assert.IsTrue(branches.Contains("master"), $"Expect master branch to be in the list for {JobType.WorkflowMultiBranchProject} job {JobNames[JobType.WorkflowMultiBranchProject]}");
             }
         }
+
+        //TODO
+        //DownloadArtifactAsync
+        //DownloadSingleArtifactAsync
+        //OpenArtifactAsync
+        //OpenSingleArtifactAsync
+        //TriggerBuildAsync
+        //GetQueuedBuildInfoAsync
+
     }
 }

--- a/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
+++ b/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
@@ -12,6 +12,7 @@ namespace Inedo.Extensions.Jenkins.Tests
     /// it does allow to quickly develop and confirm that Jenkins integration is working.
     /// 
     /// To get these tests working your Jenkins server needs the jobs listed below created and they must archive and artifact called Ezample.txt
+    /// The multi-branch demo uses https://github.com/andrew-sumner/multibranch-demo to get it's jenkinsFile
     /// </summary>
     [TestClass()]
     public class JenkinsClientTests
@@ -25,10 +26,10 @@ namespace Inedo.Extensions.Jenkins.Tests
 
         private static readonly Dictionary<JobType, string> JobNames = new Dictionary<JobType, string>()
         {
-            { JobType.FreeStyleProject, "freestyle-demo"},
-            { JobType.WorkflowJob, "pipeline-demo" },
-            { JobType.MatrixProject, "multi-config-demo" },
-            { JobType.WorkflowMultiBranchProject, "multibranch-demo" }
+            { JobType.FreeStyleProject, "demo-freestyle"},
+            { JobType.WorkflowJob, "demo-pipeline" },
+            { JobType.MatrixProject, "demo-multi-config" },
+            { JobType.WorkflowMultiBranchProject, "demo-multibranch" }
         };
 
         public JenkinsCredentials ResourceCredentials => new JenkinsCredentials()
@@ -148,10 +149,18 @@ namespace Inedo.Extensions.Jenkins.Tests
 
                     var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
 
-                    var task = Task.Run<List<JenkinsBuildArtifact>>(async () => await client.GetBuildArtifactsAsync(job.Value, "lastSuccessfulBuild").ConfigureAwait(false));
+                    var task = Task.Run<List<JenkinsBuildArtifact>>(async () => await client.GetBuildArtifactsAsync(job.Value, "lastSuccessfulBuild", branchName).ConfigureAwait(false));
                     var artifacts = task.Result;
 
-                    Assert.AreEqual(artifacts.Count, 1, $"Build should contain one artifact for {job.Key} job {job.Value}");
+                    if (job.Key == JobType.MatrixProject)
+                    {
+                        //TODO Add matix support?
+                        Assert.AreEqual(artifacts.Count, 0, $"Not currently supported for {job.Key} job {job.Value}");
+                    }
+                    else
+                    {
+                        Assert.IsTrue(artifacts.Count > 0, $"Build should contain one or more artifacts for {job.Key} job {job.Value}");
+                    }                    
                 }
             }
         }

--- a/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
+++ b/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
@@ -239,11 +239,7 @@ namespace Inedo.Extensions.Jenkins.Tests
                     continue;
 
                 using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
-                using (var tmp = TempDir.Create())
                 {
-                    var zipFileName = tmp.GetPath("archive.zip");
-                    Assert.IsFalse(File.Exists(zipFileName), $"Archive.zip should not exist prior to download for {job.Key} job {job.Value}");
-
                     var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
                     var task = Task.Run<OpenArtifact>(async () => await client.OpenArtifactAsync(job.Value, "lastSuccessfulBuild", GetTestBranchName(job.Key)).ConfigureAwait(false));
                     var openArtifact = task.Result();
@@ -263,11 +259,7 @@ namespace Inedo.Extensions.Jenkins.Tests
                     continue;
 
                 using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
-                using (var tmp = TempDir.Create())
                 {
-                    var zipFileName = tmp.GetPath("archive.zip");
-                    Assert.IsFalse(File.Exists(zipFileName), $"Archive.zip should not exist prior to download for {job.Key} job {job.Value}");
-
                     var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
 
                     var artifactTask = Task.Run<List<JenkinsBuildArtifact>>(async () => await client.GetBuildArtifactsAsync(job.Value, "lastSuccessfulBuild", GetTestBranchName(job.Key)).ConfigureAwait(false));
@@ -281,6 +273,21 @@ namespace Inedo.Extensions.Jenkins.Tests
             }
         }
 
+        [TestMethod()]
+        public void TriggerBuild()
+        {
+            foreach (var job in JobNames)
+            {
+                using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
+                {
+                    var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
+                    var task = Task.Run<int>(async () => await client.TriggerBuildAsync(job.Value, null, GetTestBranchName(job.Key)).ConfigureAwait(false));
+                    var queueId = task.Result();
+
+                    Assert.IsTrue(queueId > 0, $"queueId should be greater than zero for {job.Key} job {job.Value}");
+                }
+            }
+        }
         //TODO
         //TriggerBuildAsync
         //GetQueuedBuildInfoAsync

--- a/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
+++ b/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
@@ -1,0 +1,111 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Inedo.Extensions.Jenkins.Credentials;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+namespace Inedo.Extensions.Jenkins.Tests
+{
+    /// <summary>
+    /// These are not very good unit tests as they require a jenkins server with the correct user / token and job created, however 
+    /// it does allow to quickly develop and confirm that Jenkins integration is working.
+    /// </summary>
+    [TestClass()]
+    public class JenkinsClientTests
+    {
+        public JenkinsCredentials ResourceCredentials => new JenkinsCredentials()
+        {
+            ServerUrl = "http://inedo:8080",
+            UserName = "admin",
+            Password = AH.CreateSecureString("11b54857bc1426530dc818fcbeb4f77d34")
+        };
+
+        [TestMethod()]
+        public void GetJobNames()
+        {
+            using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
+            {
+                var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
+
+                var task = Task.Run<string[]>(async () => await client.GetJobNamesAsync().ConfigureAwait(false));
+                var jobs = task.Result;
+                
+                Assert.IsTrue(jobs.Length > 1, "Expect more than one job to be defined in Jenkins");
+            }
+        }
+
+        [TestMethod()]
+        public void GetBuildNumbers()
+        {
+            using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
+            {
+                var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
+
+                var task = Task.Run<List<string>>(async () => await client.GetBuildNumbersAsync("build-demo").ConfigureAwait(false));
+                var builds = task.Result;
+
+                Assert.IsTrue(builds.Count > 4, "Expect more than one job to be defined in Jenkins");
+                Assert.AreEqual(builds[0], "lastSuccessfulBuild", "Jenkins special build number values should be in list");
+            }
+        }
+
+        [TestMethod()]
+        [ExpectedException(typeof(System.Exception), AllowDerivedTypes = true)]
+        public void GetBuildNumbers_FromMultiBranchJob()
+        {
+            using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
+            {
+                var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
+
+                var task = Task.Run<List<string>>(async () => await client.GetBuildNumbersAsync("multibranch-demo").ConfigureAwait(false));
+                var builds = task.Result;
+
+                Assert.IsTrue(builds.Count == 4, "Expect only special build numbers to be returned");
+            }
+        }
+
+        [TestMethod()]
+        public void GetSpecialBuildNumber()
+        {
+            using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
+            {
+                var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
+
+                var task = Task.Run<string>(async () => await client.GetSpecialBuildNumberAsync("build-demo", "lastSuccessfulBuild").ConfigureAwait(false));
+                var build = task.Result;
+
+                Assert.IsTrue(long.TryParse(build, out long n), "Special build number should be converted to actual build number");
+            }
+        }
+
+        [TestMethod()]
+        public void GetBuildArtifacts()
+        {
+            using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
+            {
+                var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
+
+                var task = Task.Run<List<JenkinsBuildArtifact>>(async () => await client.GetBuildArtifactsAsync("build-demo", "lastSuccessfulBuild").ConfigureAwait(false));
+                var artifacts = task.Result;
+
+                Assert.IsTrue(artifacts.Count == 1, "Build should contain one artifact");
+            }
+        }
+
+        [TestMethod()]
+        public void GetBuildInfo()
+        {
+            using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
+            {
+                var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
+
+                var task = Task.Run<JenkinsBuild>(async () => await client.GetBuildInfoAsync("build-demo", "lastSuccessfulBuild").ConfigureAwait(false));
+                var build = task.Result;
+
+                Assert.IsFalse(build.Building, "Build should be complete");
+            }
+        }
+        
+    }
+}

--- a/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
+++ b/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
@@ -79,6 +79,11 @@ namespace Inedo.Extensions.Jenkins.Tests
 
                 Assert.IsTrue(branches.Count > 1, $"Expect more than one branch to be defined for {JobType.WorkflowMultiBranchProject} job {JobNames[JobType.WorkflowMultiBranchProject]}");
                 Assert.IsTrue(branches.Contains("master"), $"Expect master branch to be in the list for {JobType.WorkflowMultiBranchProject} job {JobNames[JobType.WorkflowMultiBranchProject]}");
+
+                foreach (var branch in branches)
+                {
+                    Assert.IsTrue(branches.FindAll(b => b.Equals(branch)).Count == 1, $"Branch name {branch} should be unique for {JobType.WorkflowMultiBranchProject} job {JobNames[JobType.WorkflowMultiBranchProject]}");
+                }
             }
         }
         
@@ -95,6 +100,11 @@ namespace Inedo.Extensions.Jenkins.Tests
 
                     Assert.IsTrue(builds.Count > 4, $"Expect more than one job to be defined for {job.Key} job {job.Value}");
                     Assert.AreEqual(builds[0], "lastSuccessfulBuild", $"Special build number values should be in list for {job.Key} job {job.Value}");
+                    
+                    foreach(var build in builds)
+                    {
+                        Assert.IsTrue(builds.FindAll(b => b.Equals(build)).Count == 1, $"Build number {build} should be unique for {job.Key} job {job.Value}");
+                    }
                 }
             }
         }

--- a/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
+++ b/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
@@ -139,6 +139,13 @@ namespace Inedo.Extensions.Jenkins.Tests
             {
                 using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
                 {
+                    string branchName = null;
+
+                    if (job.Key == JobType.WorkflowMultiBranchProject)
+                    {
+                        branchName = MasterBranch;
+                    }
+
                     var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
 
                     var task = Task.Run<List<JenkinsBuildArtifact>>(async () => await client.GetBuildArtifactsAsync(job.Value, "lastSuccessfulBuild").ConfigureAwait(false));
@@ -156,9 +163,16 @@ namespace Inedo.Extensions.Jenkins.Tests
             {
                 using (var cts = new CancellationTokenSource(new TimeSpan(0, 0, 30)))
                 {
+                    string branchName = null;
+
+                    if (job.Key == JobType.WorkflowMultiBranchProject)
+                    {
+                        branchName = MasterBranch;
+                    }
+
                     var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
 
-                    var task = Task.Run<JenkinsBuild>(async () => await client.GetBuildInfoAsync(job.Value, "lastSuccessfulBuild").ConfigureAwait(false));
+                    var task = Task.Run<JenkinsBuild>(async () => await client.GetBuildInfoAsync(job.Value, "lastSuccessfulBuild", branchName).ConfigureAwait(false));
                     var build = task.Result;
 
                     Assert.IsFalse(build.Building, $"Build should be complete for {job.Key} job {job.Value}");

--- a/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
+++ b/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
@@ -97,7 +97,7 @@ namespace Inedo.Extensions.Jenkins.Tests
             {
                 var client = new JenkinsClient(ResourceCredentials, null, cts.Token);
 
-                var task = Task.Run<List<string>>(async () => await client.GetBuildNumbersAsync(JobNames[JobType.WorkflowMultiBranchProject]).ConfigureAwait(false));
+                var task = Task.Run<List<string>>(async () => await client.GetBuildNumbersAsync(JobNames[JobType.WorkflowMultiBranchProject], "master").ConfigureAwait(false));
                 var builds = task.Result;
 
                 Assert.IsTrue(builds.Count > 4, $"Expect more than one job to be defined in Jenkins for {JobType.WorkflowMultiBranchProject} job {JobNames[JobType.WorkflowMultiBranchProject]}");

--- a/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
+++ b/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
@@ -275,7 +275,7 @@ namespace Inedo.Extensions.Jenkins.Tests
                     var artifactTask = Task.Run<List<JenkinsBuildArtifact>>(async () => await client.GetBuildArtifactsAsync(job.Value, GetTestBranchName(job.Key), "lastSuccessfulBuild").ConfigureAwait(false));
                     var artifacts = artifactTask.Result;
 
-                    var task = Task.Run<OpenArtifact>(async () => await client.OpenSingleArtifactAsync(job.Value, "lastSuccessfulBuild", GetTestBranchName(job.Key), artifacts[0]).ConfigureAwait(false));
+                    var task = Task.Run<OpenArtifact>(async () => await client.OpenSingleArtifactAsync(job.Value, GetTestBranchName(job.Key), "lastSuccessfulBuild", artifacts[0]).ConfigureAwait(false));
                     var openArtifact = task.Result();
 
                     Assert.IsTrue(openArtifact.Content.Length > 0, $"Content should be downloaded for {job.Key} job {job.Value}");

--- a/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
+++ b/Jenkins/InedoExtensionTests/JenkinsClientTests.cs
@@ -14,16 +14,19 @@ namespace Inedo.Extensions.Jenkins.Tests
     [TestClass()]
     public class JenkinsClientTests
     {
+        private enum JobType
+        {
+            FreeStyleProject, WorkflowJob, WorkflowMultiBranchProject, MavenModuleSet, MatrixProject
+        }
+
         private static readonly Dictionary<JobType, string> JobNames = new Dictionary<JobType, string>()
         {
             { JobType.FreeStyleProject, "build-demo"},
-            { JobType.WorkflowProject, "test-pipeline" },
+            { JobType.WorkflowJob, "test-pipeline" },
+            { JobType.MavenModuleSet, "maven-demo" },
+            { JobType.MatrixProject, "multi-config-demo" },
             { JobType.WorkflowMultiBranchProject, "multibranch-demo" }
         };
-
-        private enum JobType {
-            FreeStyleProject, WorkflowProject, WorkflowMultiBranchProject
-        }
 
         public JenkinsCredentials ResourceCredentials => new JenkinsCredentials()
         {
@@ -45,7 +48,7 @@ namespace Inedo.Extensions.Jenkins.Tests
                 Assert.IsTrue(jobs.Length > 1, "Expect more than one job to be defined in Jenkins");
                 
                 Assert.IsTrue(Array.IndexOf(jobs, JobNames[JobType.FreeStyleProject]) >= 0, $"FreeStyleProject ${JobNames[JobType.FreeStyleProject]} required");
-                Assert.IsTrue(Array.IndexOf(jobs, JobNames[JobType.WorkflowProject]) >= 0, $"WorkflowProject ${JobNames[JobType.WorkflowProject]} required");
+                Assert.IsTrue(Array.IndexOf(jobs, JobNames[JobType.WorkflowJob]) >= 0, $"WorkflowProject ${JobNames[JobType.WorkflowJob]} required");
                 Assert.IsTrue(Array.IndexOf(jobs, JobNames[JobType.WorkflowMultiBranchProject]) >= 0, $"WorkflowMultiBranchProject ${JobNames[JobType.WorkflowMultiBranchProject]} required");
             }
         }

--- a/Jenkins/InedoExtensionTests/Properties/AssemblyInfo.cs
+++ b/Jenkins/InedoExtensionTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("InedoExtensionTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("InedoExtensionTests")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("da60c56f-4eec-4ccc-806d-35f1ea4975cd")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Jenkins/InedoExtensionTests/TempDir.cs
+++ b/Jenkins/InedoExtensionTests/TempDir.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InedoExtensionTests
+{
+    public interface ITempDir : IDisposable
+    {
+        string Name
+        {
+            get;
+        }
+
+        string GetPath(string fileName);
+    }
+
+    public class TempDir : ITempDir
+    {
+        public string Name
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Create a temp directory named after your test in the %temp%\uTest\xxx directory
+        /// which is deleted and all sub directories when the ITempDir object is disposed.
+        /// </summary>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static ITempDir Create()
+        {
+            var stack = new StackTrace(1);
+            var sf = stack.GetFrame(0);
+            return new TempDir(sf.GetMethod().Name);
+        }
+
+        public TempDir(string dirName)
+        {
+            if (String.IsNullOrEmpty(dirName))
+            {
+                throw new ArgumentException("dirName");
+            }
+            Name = Path.Combine(Path.GetTempPath(), "uTests", dirName);
+            Directory.CreateDirectory(Name);
+        }
+
+        public void Dispose()
+        {
+
+            if (Name.Length < 10)
+            {
+                throw new InvalidOperationException(String.Format("Directory name seesm to be invalid. Do not delete recursively your hard disc.", Name));
+            }
+
+            // delete all files in temp directory
+            foreach (var file in Directory.EnumerateFiles(Name, "*.*", SearchOption.AllDirectories))
+            {
+                File.Delete(file);
+            }
+
+            // and then the directory
+            Directory.Delete(Name, true);
+        }
+
+        public string GetPath(string fileName)
+        {
+            return Path.Combine(Name, fileName);
+        }
+    }
+}

--- a/Jenkins/InedoExtensionTests/packages.config
+++ b/Jenkins/InedoExtensionTests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Inedo.SDK" version="1.3.0" targetFramework="net452" />
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net452" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net452" />
+</packages>

--- a/Jenkins/Jenkins.sln
+++ b/Jenkins/Jenkins.sln
@@ -1,28 +1,31 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29519.87
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InedoExtension", "InedoExtension\InedoExtension.csproj", "{9421990C-1CE6-41AF-BE1F-69C0E368952C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InedoExtensionTests", "InedoExtensionTests\InedoExtensionTests.csproj", "{DA60C56F-4EEC-4CCC-806D-35F1EA4975CD}"
+EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6F413381-D7B1-44C7-A18D-EDAD41762F15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6F413381-D7B1-44C7-A18D-EDAD41762F15}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6F413381-D7B1-44C7-A18D-EDAD41762F15}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6F413381-D7B1-44C7-A18D-EDAD41762F15}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9421990C-1CE6-41AF-BE1F-69C0E368952C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9421990C-1CE6-41AF-BE1F-69C0E368952C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9421990C-1CE6-41AF-BE1F-69C0E368952C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9421990C-1CE6-41AF-BE1F-69C0E368952C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA60C56F-4EEC-4CCC-806D-35F1EA4975CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA60C56F-4EEC-4CCC-806D-35F1EA4975CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA60C56F-4EEC-4CCC-806D-35F1EA4975CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA60C56F-4EEC-4CCC-806D-35F1EA4975CD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A3FED9DA-7D85-4D57-9501-5C1EAC5BBFD6}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Update extension to support additional Jenkins job types including multi-branch jobs.
- These changes allow it to work with any Jenkins job type that uses the standard api format
- Jenkins jobs types that require additional information (for example Matrix jobs) would require additional development and are outside the scope of this PR